### PR TITLE
Names which contains accent doesn't match

### DIFF
--- a/js/tests/user-profile-theme-tests.js
+++ b/js/tests/user-profile-theme-tests.js
@@ -37,7 +37,7 @@ $(function() {
 
             // Get Logged user name from Activities portlet's header
             var activitiesPortletHeader = $('th').text();
-            var activitiesPortletUserName = activitiesPortletHeader.slice(1, activitiesPortletHeader.indexOf("'")).toLowerCase();
+            var activitiesPortletUserName = activitiesPortletHeader.slice(1, activitiesPortletHeader.indexOf("'")).toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "");
 
             // Check for strings equality
             expect(urlUserName).toEqual(activitiesPortletUserName);


### PR DESCRIPTION
Hi Alfonso,

I found a small bug as my name contains an accented letter and the _"Activities portlet is relevant for the currently logged user"_ test failed on my profile page.

Feel free to solve this any other way, I'm not really familiar with JavaScript, I just found a possible solution on [Stack Overflow](https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript#answer-37511463). 

Cheers,
Tamás